### PR TITLE
feat: Week in Review — AI, SRE & Observability (March 2–8, 2026)

### DIFF
--- a/content/posts/week-in-review-ai-sre-observability-mar-2-8-2026.md
+++ b/content/posts/week-in-review-ai-sre-observability-mar-2-8-2026.md
@@ -1,0 +1,78 @@
+---
+title: "Week in Review: AI, SRE & Observability — March 2–8, 2026"
+date: 2026-03-08
+description: "GPT-5.4 ships native computer use, Kubernetes Ingress NGINX hits end of life, Google Cloud goes all-in on OTLP, and more from the week of March 2-8, 2026."
+tags: ["ai", "sre", "observability", "weekly-roundup"]
+author: "Aditya Konarde"
+showToc: true
+TocOpen: false
+hidemeta: false
+comments: false
+---
+
+This was a week where the AI race got tangibly closer to your desktop, the Kubernetes ecosystem said goodbye to an old friend, and the observability world kept tightening its grip around OpenTelemetry as the universal standard. If you only have five minutes, the headlines are: GPT-5.4 can now operate your computer better than most humans, Ingress NGINX is officially done, and Google Cloud now speaks fluent OTLP.
+
+## AI & Machine Learning
+
+**OpenAI releases GPT-5.4 with native computer use — and it beats human performance.** OpenAI's latest frontier model isn't just another benchmark bump. GPT-5.4 is the first general-purpose model to ship with production-ready computer use capabilities, scoring 75.0% on OSWorld-Verified desktop tasks — above the 72.4% human expert baseline. It supports up to 1M tokens of context, brings a new "reasoning plan preview" that lets users steer the model mid-thought, and introduces tool search for navigating large ecosystems of APIs and connectors. Available in ChatGPT (as GPT-5.4 Thinking), Codex, and the API. The agentic future just got a lot more concrete.
+[Source: OpenAI](https://openai.com/index/introducing-gpt-5-4/)
+
+**Google launches Gemini 3.1 Flash-Lite — fastest and cheapest in the Gemini 3 family.** At $0.25 per million input tokens and $1.50 per million output tokens, Flash-Lite undercuts most competitors while delivering a 2.5x faster time-to-first-token and 45% faster output speed compared to Gemini 2.5 Flash. It includes configurable "thinking levels" for developers to balance cost and reasoning depth. Early benchmarks show an Elo of 1432 on Arena.ai and 86.9% on GPQA Diamond. This is Google's play for the high-volume, cost-sensitive inference tier — translation, content moderation, and real-time analytics at scale.
+[Source: Google DeepMind](https://deepmind.google/blog/gemini-3-1-flash-lite-built-for-intelligence-at-scale/)
+
+**Microsoft open-sources Phi-4-reasoning-vision-15B — a small model that punches way above its weight.** Microsoft Research released a 15B-parameter multimodal reasoning model trained on roughly 200B tokens — a fraction of what comparable models require. It handles image captioning, document reading, chart interpretation, and UI grounding, and excels at math and science reasoning. The key insight: a hybrid mix of reasoning and non-reasoning data with explicit mode tokens lets one model deliver fast direct answers for simple tasks and chain-of-thought for hard ones. Available on HuggingFace, GitHub, and Microsoft Foundry under a permissive license.
+[Source: Microsoft Research](https://www.microsoft.com/en-us/research/blog/phi-4-reasoning-vision-and-the-lessons-of-training-a-multimodal-reasoning-model/)
+
+**OpenAI ships GPT-5.3 Instant — optimizing the model most people actually use.** While GPT-5.4 grabbed the spotlight, OpenAI also quietly released GPT-5.3 Instant, refining the lightweight model that handles the majority of everyday ChatGPT traffic. The update improves response quality, conversational flow, and reliability for routine queries. It's a signal that the industry is shifting from pure capability races to infrastructure optimization — making AI cheaper and more reliable at the scale of millions of daily interactions.
+[Source: The Next Web](https://thenextweb.com/news/openai-launches-gpt-5-3-instant-to-improve-chatgpts-most-used-model)
+
+## Site Reliability Engineering
+
+**Kubernetes Ingress NGINX reaches end of life — time to migrate.** The clock has run out. As of March 2026, the community-maintained Ingress NGINX controller — the de facto standard for routing external traffic into Kubernetes clusters for nearly a decade — is no longer receiving security patches, bug fixes, or compatibility updates. The Kubernetes SIG Network and Security Response Committee announced this retirement back in November 2025, but now it's real. The recommended path forward is the Gateway API, with alternatives like NGINX Gateway Fabric, Kong, Traefik, or HAProxy for teams that need a bridge. If you haven't started your migration planning, Monday morning is the time.
+[Source: Kubernetes Blog](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
+
+**CNCF: 82% of container users now run Kubernetes in production, and AI workloads are driving convergence.** A CNCF blog post this week laid out the case that Kubernetes has become the unified platform for data processing, model training, inference, and AI agent workloads. According to CNCF's January 2026 survey, 66% of organizations hosting generative AI models use Kubernetes for some or all inference workloads. The piece traces three eras of Kubernetes — microservices, data and GenAI, and the current agentic era — and argues the platform is converging around all of them simultaneously.
+[Source: CNCF Blog](https://www.cncf.io/blog/2026/03/05/the-great-migration-why-every-ai-platform-is-converging-on-kubernetes/)
+
+**Thoughtworks publishes "SRE is entering a paradigm shift" — a first-principles rethink.** This thoughtful piece argues that as systems become cognitive and partially autonomous (think AI agents making runtime decisions), the traditional SRE control model — built on the assumption that systems are observable, modelable, predictable, and intervenable — starts to break down. When AI introduces stochastic decision-making into the system itself, observability requirements change fundamentally. Whether you agree with the framing or not, it's the kind of strategic thinking SRE leaders should be engaging with.
+[Source: Thoughtworks](https://www.thoughtworks.com/insights/blog/generative-ai/sre--is-entering-a-paradigm-shift)
+
+**Argo CD 3.3 ships PreDelete hooks, OIDC background refresh, and shallow clones.** The Argo CD 3.3 release candidate fills a long-standing gap: PreDelete hooks that let you run cleanup logic (data backups, external teardown) before application deletion, with deletion blocked if the cleanup fails. Other highlights include background OIDC token refresh (no more Keycloak session timeouts every five minutes), granular RBAC with resource name whitelisting for CRDs, and shallow clone support for large monorepos. If you're running GitOps at scale, this is a meaningful quality-of-life upgrade.
+[Source: Argo Project Blog](https://blog.argoproj.io/argo-cd-3-3-release-candidate-00e99f7b7daa)
+
+## Observability
+
+**Google Cloud adds full OTLP support for Cloud Monitoring metrics.** Google Cloud now accepts metrics in OpenTelemetry Protocol format alongside traces and logs, completing the OTLP trifecta in Cloud Observability. This means you can use OpenTelemetry SDKs and Collectors to send all three signal types through a vendor-agnostic pipeline. New features include delta-type metrics (reducing client-side memory), exponential histograms for dynamic bucket sizing, and expanded naming conventions aligned with OTel semantic conventions. Ingested OTLP metrics are stored like Prometheus data and queryable with existing Monitoring tools.
+[Source: Google Cloud Blog](https://cloud.google.com/blog/products/management-tools/otlp-opentelemetry-protocol-for-google-cloud-monitoring-metrics)
+
+**Atlassian ships OpenTelemetry traces for Bitbucket Pipelines via webhooks.** Bitbucket Pipelines now exposes pipeline execution as OTel traces delivered through webhook events. You get structured spans for each run, step, command, and container — including CPU and memory resource metrics — in a standard format ingestible by Grafana, Datadog, Honeycomb, and any OTLP-compatible backend. This is a significant step toward treating CI/CD pipelines as first-class observable infrastructure rather than opaque black boxes. The integration answers questions like "which part of this pipeline is slow?" and "are we hitting resource limits on build containers?"
+[Source: Atlassian Blog](https://www.atlassian.com/blog/bitbucket/bitbucket-pipelines-opentelemetry-traces-via-webhooks)
+
+**OpenTelemetry Collector gets OTTL context inference in the Filter Processor.** Starting with collector-contrib v0.146.0, the Filter Processor supports context inference through four new top-level config fields: `trace_conditions`, `metric_conditions`, `log_conditions`, and `profile_conditions`. Previously, writing filter rules required understanding the Collector's internal telemetry hierarchy and splitting conditions across distinct context blocks. Now you write flat condition lists and let the Collector infer whether a condition applies to a resource, span, or log context. It's a small but meaningful usability improvement that reduces configuration errors.
+[Source: OpenTelemetry Blog](https://opentelemetry.io/blog/2026/ottl-context-inference-come-to-filterprocessor/)
+
+**The "observability tax" conversation heats up — enterprises pivot to OpenTelemetry for cost control.** Multiple pieces this week covered the growing frustration with observability costs, with 66% of enterprises reporting unexpected overages on observability tooling. The core argument: standardizing on OpenTelemetry eliminates the duplicated engineering effort of building custom pipelines, reduces vendor lock-in premiums, and lets teams route telemetry data more efficiently. Combined with eBPF-based collection (sub-1% CPU overhead) and tiered collector architectures, organizations are finding they can cut costs while improving coverage.
+[Source: IPv6.net](https://ipv6.net/news/the-end-of-the-observability-tax-why-enterprises-are-pivoting-to-opentelemetry/)
+
+## Quick Links
+
+- **Calico Winter 2026 release** adds an AI-powered assistant for natural language cluster troubleshooting and a unified ingress gateway dashboard — [Tigera Blog](https://www.tigera.io/blog/whats-new-in-calico-winter-2026-release/)
+- **OpenAI releases Symphony**, an open-source framework for orchestrating autonomous AI coding agents through structured implementation runs — [MarkTechPost](https://www.marktechpost.com/2026/03/05/openai-releases-symphony-an-open-source-agentic-framework-for-orchestrating-autonomous-ai-agents-through-structured-scalable-implementation-runs/)
+- **Cilium 1.19 released**, celebrating 10 years of eBPF-based networking with security hardening, stricter encryption modes, and improved scalability for large clusters — [InfoQ](https://www.infoq.com/news/2026/02/cilium-119/)
+- **Sematext publishes architecture patterns** for running OpenTelemetry at scale across hundreds of services, covering collector tiers, load balancing, and multi-cluster setups — [Sematext Blog](https://sematext.com/blog/running-opentelemetry-at-scale-architecture-patterns-for-100s-of-services/)
+- **KubeCon EU 2026 is less than three weeks away** (March 23-26 in Amsterdam) — if you're heading there, the program is live and registration is still open — [CNCF](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/)
+- **ObservabilityCON on the Road** continues its 2026 world tour with Toronto (March 5) done and Sydney (March 10), Tokyo (March 17), and Amsterdam (March 31) coming up — [Grafana Labs](https://grafana.com/blog/observabilitycon-on-the-road-new-cities-new-sessions-in-2026/)
+
+## My Take
+
+The thread connecting this week's biggest stories is convergence. GPT-5.4's computer use capabilities and the CNCF's survey data both point to the same reality: AI workloads are no longer a separate world from infrastructure operations. They're running on the same Kubernetes clusters, instrumented with the same OpenTelemetry pipelines, and increasingly *making decisions* inside systems that SREs are responsible for keeping reliable.
+
+Thoughtworks' paradigm shift piece crystallizes the tension. When your system includes AI agents that make stochastic runtime decisions, the traditional SRE contract — that systems should be observable, modelable, and predictable — needs serious rethinking. The observability stack has to evolve from "tell me what happened" to "tell me what the AI decided and why." That's a fundamentally harder problem, and it's one reason the push toward standardized, vendor-neutral telemetry (OTLP everywhere, OTel at scale) matters so much. You can't debug cognitive systems with fragmented, proprietary instrumentation.
+
+Meanwhile, the Ingress NGINX retirement is a reminder that even foundational infrastructure components have a lifecycle. The Kubernetes ecosystem moves fast, and the Gateway API represents a genuinely better abstraction. If you're still planning your migration, the clock isn't ticking anymore — it's already stopped.
+
+---
+
+*What caught your eye this week? I'd love to hear your thoughts — find me on [LinkedIn](https://www.linkedin.com/in/aditya-konarde/) or [X](https://twitter.com/aditya_konarde).*
+
+*Subscribe to stay updated on the latest across AI, SRE, and Observability.*


### PR DESCRIPTION
# Add weekly roundup blog post: AI, SRE & Observability (Mar 2–8, 2026)

## Summary

New blog post covering the week's developments across three domains:

- **AI/ML (4 stories):** GPT-5.4 with native computer use, Gemini 3.1 Flash-Lite, Microsoft's Phi-4-reasoning-vision-15B, GPT-5.3 Instant
- **SRE (4 stories):** Ingress NGINX EOL, CNCF K8s + AI convergence survey, Thoughtworks SRE paradigm shift piece, Argo CD 3.3 RC
- **Observability (4 stories):** Google Cloud OTLP metrics support, Bitbucket Pipelines OTel traces, OTTL context inference in Filter Processor, observability cost/OpenTelemetry pivot trend
- **Quick Links (6 items):** Calico Winter 2026, OpenAI Symphony, Cilium 1.19, Sematext OTel patterns, KubeCon EU 2026, ObservabilityCON on the Road
- **Editorial section** tying themes together (AI + infra convergence, SRE paradigm shift, OTel standardization)

Also adds 44 new words to `.spellcheck-words.txt` to pass CI spell check.

## Review & Testing Checklist for Human

- [ ] **Spot-check factual claims against source links** — key numbers (GPT-5.4 OSWorld 75.0%, Gemini pricing $0.25/1M input, Phi-4 15B params/200B tokens, CNCF 82%/66% stats) were pulled from web research and should be verified against the linked sources
- [ ] **Verify all source links resolve** — CI link checker should catch broken ones, but check that none are paywalled or redirecting unexpectedly. Note: the Ingress NGINX source links to the [Nov 2025 announcement](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) (original EOL notice) and the Argo CD 3.3 RC source links to the [Dec 2025 Argo blog post](https://blog.argoproj.io/argo-cd-3-3-release-candidate-00e99f7b7daa) — both are timely topics but the sources predate this week
- [ ] **Review tone and voice** — this was AI-written on your behalf; confirm it reads like your voice and adjust any phrasing that feels off
- [ ] **Preview the rendered post in Hugo** — run `hugo server` locally or check the Netlify preview deploy to confirm formatting, TOC, links, and metadata render correctly
- [ ] **Glance at spellcheck wordlist additions** — 44 words added, mostly technical terms; confirm nothing inappropriate slipped in

### Notes
- Markdownlint passes cleanly. Spellcheck passes for the new post (remaining failures are pre-existing in other posts).
- The husky pre-commit hook requires `bun` which isn't in the dev environment, so the commit was made with `HUSKY=0`. The hook's lint-staged config is a no-op (`echo 'No linting configured'`), so this has no impact.
- Session: https://app.devin.ai/sessions/e0b77f86a3264aaa9cadf71620332d32 (requested by @aditya-konarde)