### PR TITLE
Add weekly roundup: AI, SRE & Observability — March 14–20, 2026

### DIFF
--- a/content/posts/week-in-review-2026-03-14-20.md
+++ b/content/posts/week-in-review-2026-03-14-20.md
@@ -1,0 +1,107 @@
+---
+title: "Week in Review: AI, SRE & Observability — March 14–20, 2026"
+date: 2026-03-20
+tags: ["ai", "sre", "observability", "weekly-roundup"]
+description: "GTC 2026 dominates the AI narrative, agentic SRE goes mainstream across every major cloud, and OpenTelemetry makes bold moves on span events and Kubernetes semantic conventions."
+author: "Aditya Konarde"
+showToc: true
+TocOpen: false
+hidemeta: false
+comments: false
+---
+
+GTC week is always loud, but this one hit different. NVIDIA unveiled a trillion-dollar infrastructure roadmap while OpenAI quietly absorbed one of Python's most beloved open-source teams. Meanwhile, the SRE world went all-in on agentic AI, with PagerDuty, Komodor, and Microsoft all shipping agent-driven incident response features in the same week. And on the observability front, OpenTelemetry made a significant architectural decision that'll ripple through every tracing backend for years. Buckle up.
+
+## AI & Machine Learning
+
+### NVIDIA GTC 2026: Vera Rubin, $1T in demand, and the agentic AI stack
+
+Jensen Huang's keynote was the main event. NVIDIA unveiled the Vera Rubin platform, a rack-scale supercomputer integrating seven co-designed chips built for the agentic inference era. The headline number: $1 trillion in projected demand for Blackwell and Vera Rubin platforms through 2027, double last year's forecast. Alongside Vera Rubin, NVIDIA launched OpenClaw, an open-source agentic AI framework Huang compared to "Windows for AI agents," and Dynamo 1.0 for inference orchestration. The message is clear: NVIDIA sees inference, not training, as the next mega-cycle.
+[NVIDIA GTC 2026 coverage (Data Center Knowledge)](https://www.datacenterknowledge.com/data-center-chips/gtc-2026-nvidia-unveils-vera-rubin-ai-platform-eyes-1t-by-2027)
+
+### OpenAI acquires Astral: uv, Ruff, and ty join the Codex team
+
+In a move that sent ripples through the Python ecosystem, OpenAI announced it will acquire Astral, the company behind uv (package manager), Ruff (linter/formatter), and ty (type checker). The Astral team joins OpenAI's Codex group, which now has over 2 million weekly active users. Both sides promise the tools will remain open source, but the Hacker News thread hit 757 points and 475 comments in hours, with the community mood landing somewhere between cautious and anxious. The real question: is this about the talent (including BurntSushi of ripgrep fame) or the products? Likely both.
+[Astral announcement](https://astral.sh/blog/openai) | [Simon Willison's analysis](https://simonwillison.net/2026/mar/19/openai-acquiring-astral/)
+
+### Claude Opus 4.6 finds 22 Firefox vulnerabilities in two weeks
+
+Anthropic's Claude Opus 4.6 discovered 22 security vulnerabilities in Firefox, 14 of which earned high-severity classifications. That's nearly 20% of all high-severity Firefox bugs patched throughout 2025, found in just two weeks. Mozilla validated the findings and shipped fixes in Firefox 148. Unlike typical AI-generated bug reports (which Mozilla's engineers described as "garbage"), these came with minimal test cases, detailed proofs of concept, and candidate patches. The implications cut both ways: AI-powered security auditing is becoming genuinely useful, but the same capabilities could accelerate exploit development.
+[InfoQ coverage](https://www.infoq.com/news/2026/03/claude-ai-firefox-vulnerability/)
+
+### White House AI regulation framework imminent
+
+The White House is expected to release an AI regulation framework within days, including preemption of state laws. This will kick off congressional negotiations on bill text. For AI practitioners, this could mean new compliance requirements for model deployment and usage. The details are still behind closed doors, but the timing, during GTC week, is likely not coincidental.
+[Punchbowl News](https://punchbowl.news/article/tech/white-house-ai-framework-2/)
+
+## Site Reliability Engineering
+
+### Anthropic's SRE team on using Claude for incident response (and why it's not enough)
+
+At QCon London, Alex Palcuie from Anthropic's AI reliability engineering team gave a remarkably honest talk about using Claude for incident response. Key takeaway: Claude is fantastic at the "observe" and "orient" phases, searching logs at I/O speed and summarizing vast amounts of telemetry data. But it consistently mistakes correlation for causation during the "decide" phase. Palcuie's team exists specifically to keep Claude running, and they're actively hiring, which he noted is proof enough that AI hasn't replaced SREs. "It would be hypocritical to say that Claude fixes everything," he said. A refreshingly grounded perspective.
+[The Register](https://www.theregister.com/2026/03/19/anthropic_claude_sre/)
+
+### PagerDuty ships agentic SRE with virtual responders and MCP integration
+
+PagerDuty's Spring 2026 release evolves its SRE Agent into a virtual responder that can be embedded directly into on-call schedules and escalation policies. The agent handles detection, triage, and initial diagnostics before escalating to humans. Notable additions include deeper Slack-native incident workflows and a multi-agent ecosystem built on Model Context Protocol (MCP). This is one of the clearest signals yet that the industry is treating AI agents as first-class participants in operational workflows, not just assistants.
+[Analysis (Efficiently Connected)](https://www.efficientlyconnected.com/pagerduty-advances-toward-autonomous-operations-with-agentic-sre-and-multi-agent-workflows/)
+
+### Komodor launches multi-agent extensibility framework for Kubernetes SRE
+
+Komodor unveiled a new extensibility framework for its Klaudia AI platform, enabling organizations to combine their own tools and agents with Komodor's 50+ specialized agents for Kubernetes troubleshooting. The system coordinates agents working in parallel across Kubernetes, GPUs, networking, and storage layers, mirroring how human SRE teams actually work during complex incidents. The pitch: multi-domain incidents investigated at machine speed.
+[Komodor blog](https://komodor.com/blog/komodor-introduces-extensible-autonomous-multi-agent-architecture-for-ai-driven-site-reliability-engineering)
+
+### Azure SRE Agent hits general availability
+
+Microsoft's Azure SRE Agent, which continuously observes telemetry, correlates incidents with recent changes, and assists with remediation, went GA this week after several months in public preview. Unlike traditional AIOps tools, it operates as a genuine agentic system integrated natively with incident management workflows. Elastic published a same-day integration guide showing how to pair it with Elasticsearch for higher-fidelity data foundations.
+[Azure SRE Agent overview](https://www.007ffflearning.com/post/azure-sre-agent-intro/) | [Elastic integration guide](https://www.elastic.co/observability-labs/blog/azure-sre-agent-elasticsearch)
+
+## Observability
+
+### OpenTelemetry deprecates the Span Events API
+
+This is a big architectural decision. OpenTelemetry officially announced the deprecation of the Span Events API, moving toward a unified model where events are logs correlated with spans via context. The rationale: having two overlapping ways to emit events (span events and log-based events) created duplicate concepts, split guidance for instrumentation authors, and slowed evolution of the event model. Existing span event data will keep working, but new code should use the Logs API. If you maintain OTel instrumentation, start planning the migration now.
+[OpenTelemetry blog](https://opentelemetry.io/blog/2026/deprecating-span-events/)
+
+### Grafana Labs releases 2026 Observability Survey: open standards win, AI welcomed cautiously
+
+Grafana Labs published its fourth annual Observability Survey, the largest yet with 1,300+ respondents across 76 countries. The headline stats: 77% say open source and open standards are important to their observability strategy, 92% see value in AI for anomaly detection, but only 77% trust AI to take autonomous actions, and 15% don't trust it at all. Half of organizations now use observability tools for business metrics, not just infrastructure. The survey confirms what many practitioners feel: OpenTelemetry is becoming the default, and the industry is shifting from vendor-locked to open and portable.
+[Grafana Labs survey results](https://grafana.com/blog/observability-survey-OSS-open-standards-2026) | [Press release](https://grafana.com/press/2026/03/18/grafana-labs-4th-annual-observability-survey-reveals-a-field-at-a-crossroads-ai-economics-complexity-and-the-enduring-power-of-open-source/)
+
+### Kubernetes attributes reach release candidate in OTel Semantic Conventions
+
+The Kubernetes Semantic Conventions SIG promoted Kubernetes attributes to release candidate status in OpenTelemetry. This is the culmination of months of focused work aligning with the Collector SIG's goal to stabilize the `k8sattributes` processor. Users can try the new schema via feature gates and provide feedback before the final stable release. For teams running OTel Collectors in Kubernetes environments, this is a meaningful step toward production-grade stability.
+[OpenTelemetry blog](https://opentelemetry.io/blog/2026/k8s-semconv-rc/)
+
+### Signal Studio: a dry-run mode for the OpenTelemetry Collector
+
+Canonical published a deep dive on Signal Studio, a new tool that adds a diagnostic "plan" mode to OpenTelemetry Collectors. Think `terraform plan` but for telemetry pipelines. It combines static configuration analysis with live metrics and an ephemeral OTLP tap to evaluate filter behavior against observed traffic. For anyone who has nervously edited Collector YAML in production and crossed their fingers, this addresses a real gap in the open-source observability toolchain.
+[Canonical blog](https://canonical.com/blog/building-a-dry-run-mode-for-the-opentelemetry-collector)
+
+### Alibaba Cloud and Datadog release OpenTelemetry Go auto-instrumentation tool
+
+Alibaba Cloud and Datadog jointly released an open-source OpenTelemetry Go automatic instrumentation tool that uses compile-time injection to enable zero-code tracing. Go's static compilation has long made automatic instrumentation difficult compared to Java's bytecode enhancement. The tool, donated to the OpenTelemetry community as `opentelemetry-go-compile-instrumentation`, intercepts the Go compiler via `-toolexec` to analyze and modify code before compilation. The first preview version (v0.1.0) is available now.
+[Dev.to writeup](https://dev.to/observabilityguy/alibaba-cloud-observability-and-datadog-release-opentelemetry-go-automatic-instrumentation-tool-4gbc)
+
+## Quick Links
+
+- **OpenTelemetry Collector v0.148.0 released** with breaking changes including removal of the SAPM exporter and k8slog receiver. [Release notes](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.148.0)
+- **Google launches multi-cluster GKE Inference Gateway** for model-aware load balancing across regions and clusters. [Google Cloud blog](https://cloud.google.com/blog/products/containers-kubernetes/multi-cluster-gke-inference-gateway-helps-scale-ai-workloads)
+- **Kubernetes 1.36 preview**: expected April 22, with DRA improvements, Gateway API updates, and the ingress-nginx retirement. [Cloud Native Now](https://cloudnativenow.com/features/what-to-expect-from-kubernetes-1-36/)
+- **Kubernetes image promoter (kpromo) rewrite** shipped silently: 20% less code, dramatically faster, zero user-visible changes. [Kubernetes blog](https://kubernetes.io/blog/2026/03/17/image-promoter-rewrite/)
+- **KubeCon EU 2026 co-located events announced** including Platform Engineering Day with increased focus on AI within platform engineering. [CNCF blog](https://www.cncf.io/blog/2026/03/19/kubecon-cloudnativecon-europe-2026-co-located-event-deep-dive-platform-engineering-day/)
+- **Red Hat's OpenShift** positioning as the enterprise hybrid AI platform at KubeCon EU. [SiliconANGLE](https://siliconangle.com/2026/03/18/red-hats-infrastructure-shift-enterprise-kubeconeu/)
+
+## My Take
+
+The theme this week is convergence. AI agents are no longer experimental add-ons; they're becoming first-class participants in operational workflows. PagerDuty puts them on-call schedules. Komodor orchestrates them like parallel SRE teams. Azure gives them GA status with native incident management integration. And Anthropic's own SRE team honestly admits they're useful but flawed, a degree of self-awareness the rest of the industry should take to heart.
+
+Meanwhile, the observability world is making the kind of bold, breaking-change decisions that signal maturity. Deprecating span events in favor of unified log-based events is the right call architecturally, even if it'll cause short-term pain for instrumentation maintainers. Combined with Kubernetes semantic conventions reaching RC and the Grafana survey confirming that 77% of practitioners now anchor their strategies around open standards, the trajectory is clear: OpenTelemetry is becoming the lingua franca of operational telemetry, and everyone is building around it.
+
+The NVIDIA keynote and the Astral acquisition share a common thread too: the infrastructure layer for AI is consolidating fast. Whether it's silicon (Vera Rubin), software (OpenClaw), or developer tooling (uv, Ruff joining Codex), the companies with the capital are assembling full-stack AI platforms. For practitioners, this means more powerful tools, but also more concentration of control. Worth watching closely.
+
+---
+
+*What caught your eye this week? I'd love to hear your thoughts: [LinkedIn](https://www.linkedin.com/in/aditya-konarde/)*
+
+*If you found this useful, share it with your team and subscribe for next week's roundup.*


### PR DESCRIPTION
## Summary

Adds a new weekly roundup blog post covering AI/ML, SRE, and Observability developments from the week of March 14–20, 2026.

**Content structure:**
- 4 AI/ML stories (GTC 2026 / Vera Rubin, OpenAI acquires Astral, Claude finding Firefox vulns, White House AI framework)
- 4 SRE stories (Anthropic's SRE team at QCon, PagerDuty agentic SRE, Komodor multi-agent framework, Azure SRE Agent GA)
- 5 Observability stories (OTel Span Events deprecation, Grafana 2026 survey, K8s semconv RC, Signal Studio, OTel Go auto-instrumentation)
- 6 quick links, editorial section, and sign-off

Single new file: `content/posts/week-in-review-2026-03-14-20.md`. No code, config, or dependency changes. Passes `markdownlint-cli` locally.

## Review & Testing Checklist for Human

- [ ] **Factual accuracy**: Verify key claims and statistics against the linked sources — especially numbers like "$1 trillion," "22 vulnerabilities," "77% of respondents," "2 million weekly active users." These were gathered via web search and could be misquoted or missing nuance.
- [ ] **Link verification**: Click through all external links to confirm they resolve and point to the correct content. Pay special attention to the Azure SRE Agent link (third-party blog, not official Microsoft docs) and the Punchbowl News link (may be paywalled).
- [ ] **Voice and tone**: The "My Take" editorial section expresses opinions published under your name. Read it carefully and adjust anything that doesn't reflect your actual views.
- [ ] **Hugo rendering**: Run `hugo server` locally or check the Netlify preview deploy to confirm the post renders correctly with PaperMod (ToC, heading hierarchy, link formatting).
- [ ] **Spellcheck CI**: The repo has a custom spellcheck wordlist (`.spellcheck-words.txt`). New terms like "OpenClaw," "NemoClaw," "Klaudia," "kpromo" etc. may need to be added if spellcheck CI fails.

### Notes

- All stories sourced from verifiable public sources published between March 13–20, 2026.
- Frontmatter follows the existing convention used by other posts in the repo (PaperMod theme fields like `showToc`, `TocOpen`, `hidemeta`, `comments`).

Link to Devin session: https://app.devin.ai/sessions/c2e232497444439694b9ae6e537b5b32
Requested by: @aditya-konarde