### PR TITLE
Add weekly roundup: AI, SRE & Observability -- April 17-24, 2026

### DIFF
--- a/content/posts/week-in-review-ai-sre-observability-apr-17-24-2026.md
+++ b/content/posts/week-in-review-ai-sre-observability-apr-17-24-2026.md
@@ -30,7 +30,7 @@ Anthropic released Claude Opus 4.7 on April 16, shipping notable improvements ov
 
 ## Site Reliability Engineering
 
-**Kubernetes 1.36 "Haru" ships with 70 enhancements, including gang scheduling for AI workloads** --
+**Kubernetes 1.36 "Haru" ships with 68 enhancements, including gang scheduling for AI workloads** --
 Kubernetes 1.36 dropped on April 22 with 18 stable, 25 beta, and 25 alpha features. The standout for AI teams: gang scheduling enters alpha, letting the scheduler guarantee all-or-nothing pod placement for distributed training and batch inference jobs instead of processing pods individually (which wastes resources when only half a gang gets scheduled). Fine-grained kubelet API authorization goes GA, applying least-privilege access to individual kubelet endpoints -- a big win for observability setups that previously required broad node proxy permissions. Resource Health Status moves to beta with DRA support, so you can now determine whether pod crashes correlate with unhealthy or unknown device states on GPUs and other dynamic resources. User namespaces also graduate to stable.
 [Source](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/)
 

--- a/content/posts/week-in-review-ai-sre-observability-apr-17-24-2026.md
+++ b/content/posts/week-in-review-ai-sre-observability-apr-17-24-2026.md
@@ -1,0 +1,82 @@
+---
+title: "Week in Review: AI, SRE & Observability -- April 17-24, 2026"
+date: 2026-04-24
+tags: ["ai", "sre", "observability", "weekly-roundup"]
+description: "A massive week: OpenAI ships GPT-5.5, DeepSeek drops V4 hours later, Kubernetes 1.36 lands with gang scheduling for AI workloads, GrafanaCON delivers Grafana 13 and a Loki rearchitecture -- and Vercel's OAuth supply-chain breach becomes the security story everyone's talking about."
+author: "Aditya Konarde"
+showToc: true
+TocOpen: true
+hidemeta: false
+comments: false
+canonicalURL: ""
+searchHidden: false
+---
+
+If you blinked this week, you missed a model war. OpenAI dropped GPT-5.5 on Wednesday; DeepSeek shipped V4 -- open-source, 1.6T parameters, Apache 2.0 -- within hours. Meanwhile, Kubernetes 1.36 landed with gang scheduling for AI batch workloads, GrafanaCON in Barcelona delivered Grafana 13 and a ground-up Loki rearchitecture, and Vercel disclosed an OAuth supply-chain breach that should make every platform team audit their third-party integrations today. This was one of those weeks where multiple tectonic plates moved at once.
+
+## AI and Machine Learning
+
+**OpenAI releases GPT-5.5 -- "a new class of intelligence for real work"** --
+OpenAI shipped GPT-5.5 on April 23, calling it their smartest model yet. The headline numbers: 82.7% on Terminal-Bench 2.0, 58.6% on SWE-Bench Pro, and strong gains on internal Expert-SWE evaluations for long-horizon coding. The model matches GPT-5.4 per-token latency while using fewer tokens on equivalent Codex tasks, meaning it's both smarter and cheaper to run. It's rolling out to Plus, Pro, Business, and Enterprise users in ChatGPT and Codex, with API access coming soon.
+[Source](https://openai.com/index/introducing-gpt-5-5/)
+
+**DeepSeek ships V4 -- open-source, 1.6T parameters, same-day counter-launch** --
+Hours after GPT-5.5, DeepSeek released V4 in preview: a 1.6T-parameter MoE model (49B activated) with a 1M-token context window, Apache 2.0 license, and weights on Hugging Face. The Flash variant (284B total, 13B activated) is separately trained, not a trimmed Pro. API pricing lands at $1.74/$3.48 per million tokens for Pro -- significantly cheaper than Opus 4.7, GPT-5.5, or competitors. V4 introduces Compressed Sparse Attention (CSA) and Heavily Compressed Attention (HCA) to cut KV cache requirements by roughly 10x. The model was pre-trained on 32T+ tokens using FP4+FP8 mixed precision. Huawei also announced its Ascend 950-based supernode will fully support V4.
+[Source](https://api-docs.deepseek.com/news/news0424)
+
+**Anthropic launches Claude Opus 4.7 with stronger coding and high-res vision** --
+Anthropic released Claude Opus 4.7 on April 16, shipping notable improvements over Opus 4.6 in advanced software engineering -- particularly on the hardest tasks. The model can now accept images up to 2,576 pixels on the long edge (3x the prior limit), making it significantly better at interpreting charts, dense documents, and UIs. A new "xhigh" effort level gives developers control over the reasoning-depth-vs-latency tradeoff. Pricing stays at $5/$25 per million tokens. Alongside the launch, Anthropic introduced a Cyber Verification Program that gives vetted security researchers full model access without standard restrictions -- a direct response to the Project Glasswing findings about AI cybersecurity risk.
+[Source](https://www.anthropic.com/news/claude-opus-4-7)
+
+## Site Reliability Engineering
+
+**Kubernetes 1.36 "Haru" ships with 70 enhancements, including gang scheduling for AI workloads** --
+Kubernetes 1.36 dropped on April 22 with 18 stable, 25 beta, and 25 alpha features. The standout for AI teams: gang scheduling enters alpha, letting the scheduler guarantee all-or-nothing pod placement for distributed training and batch inference jobs instead of processing pods individually (which wastes resources when only half a gang gets scheduled). Fine-grained kubelet API authorization goes GA, applying least-privilege access to individual kubelet endpoints -- a big win for observability setups that previously required broad node proxy permissions. Resource Health Status moves to beta with DRA support, so you can now determine whether pod crashes correlate with unhealthy or unknown device states on GPUs and other dynamic resources. User namespaces also graduate to stable.
+[Source](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/)
+
+**Vercel discloses OAuth supply-chain breach originating from third-party AI tool** --
+On April 19, Vercel disclosed a security incident that's become this week's must-read postmortem. The attack didn't start at Vercel -- it started at Context.ai, a third-party AI SaaS, where an employee was infected with Lumma Stealer. The attacker used stolen OAuth tokens to pivot through Google Workspace into a Vercel employee's corporate account, then accessed internal environments and read a subset of customer environment variables not marked "sensitive." The detection gap: roughly 22 months, from mid-2024 to April 2026. Mandiant and law enforcement are involved. The lesson is uncomfortable: your supply chain isn't just your code and npm packages anymore -- it's every SaaS app your employees authenticate with via OAuth.
+[Source](https://vercel.com/blog/postmortem-supply-chain-attack)
+
+**Gateway API v1.5 ships biggest release yet -- six features graduate to stable** --
+Gateway API v1.5, released in March but getting widespread adoption this month, is the project's largest release to date. Six widely-requested features move to the Standard (stable) channel: ListenerSet for multi-tenant listener management, TLSRoute, HTTPRoute CORS Filter, Client Certificate Validation, Certificate Selection for Gateway TLS Origination, and ReferenceGrant. The project has also moved to a release-train model, which should produce a more predictable cadence going forward. For teams still on Ingress: this is the release that closes most of the remaining feature gaps.
+[Source](https://kubernetes.io/blog/2026/04/21/gateway-api-v1-5/)
+
+## Observability
+
+**GrafanaCON 2026: Grafana 13 launches with suggested dashboards, Git Sync GA, and AI Assistant everywhere** --
+Grafana Labs held GrafanaCON in Barcelona this week and shipped a stack of updates. Grafana 13 introduces suggested dashboards (auto-surfacing pre-built dashboards for connected data sources), dynamic dashboards GA, and a Graphviz panel. Git Sync is now generally available, enabling native GitOps for dashboard management. The AI-powered Grafana Assistant is expanding beyond Grafana Cloud to OSS and Enterprise users via a one-click Cloud connection. The new Grafana Advisor tool runs health checks and provides optimization recommendations. Grafana now counts 35 million users worldwide.
+[Source](https://grafana.com/blog/grafanacon-2026-announcements/)
+
+**Grafana rearchitects Loki with Kafka -- eliminates 2.3x storage overhead** --
+The most technically significant GrafanaCON announcement: Loki is getting a new Kafka-backed ingestion architecture. The current design replicates every log line to three ingesters for HA, but drift between ingesters means deduplication fails -- Grafana's internal metrics show they store 2.3x the data they ingest on average. The new architecture replaces replication-at-ingestion with Kafka as the durability layer, eliminating this overhead entirely. The result: 10x faster aggregated queries and dramatically lower storage costs. This is the kind of foundational change that makes self-hosted Loki significantly more viable at scale.
+[Source](https://www.infoq.com/news/2026/04/grafana-loki-ai-agents/)
+
+**Grafana Labs targets the "AI blind spot" with LLM observability and agent-aware CLI** --
+Also at GrafanaCON: Grafana launched AI Observability in Grafana Cloud (public preview) for monitoring LLM-powered applications in production -- tracking token usage, latency, error rates, and evaluation metrics in real time. They also shipped GCX, a new agent-aware CLI designed to surface Grafana Cloud data inside agentic development environments. And o11y-bench, an open-source benchmark for evaluating AI agents running observability workflows, is now available. The quote from Jen Villa, Senior Director of Product: "AI systems are starting to look a lot like distributed systems did a decade ago: powerful, but difficult to reason about and even harder to operate."
+[Source](https://grafana.com/press/2026/04/21/grafana-labs-targets-the-ai-blind-spot-with-new-observability-tools-announced-at-grafanacon-2026/)
+
+**OpenTelemetry formally deprecates OpenTracing compatibility requirements** --
+The OpenTelemetry Specification project merged the deprecation of OpenTracing compatibility requirements, effective as of March 2026 with earliest removal no sooner than March 2027. Implementing new OpenTracing compatibility is no longer required for new SDKs. Existing shims can be maintained for backwards compatibility during the deprecation period, but all new work should target native OTel APIs and OTLP-based workflows. If you're still depending on an OpenTracing shim, now is the time to plan your migration.
+[Source](https://opentelemetry.io/blog/2026/deprecating-opentracing-compatibility/)
+
+## Quick Links
+
+- **Kong launches Agent Gateway for multi-agent AI traffic** -- AI Gateway 3.14 adds governance for agent-to-agent communication alongside LLM and MCP traffic, with unified observability in Konnect. [Kong](https://konghq.com/blog/product-releases/agent-gateway)
+- **OpenTelemetry eBPF Instrumentation (OBI) hits beta** -- The successor to Grafana Beyla reaches v0.8.0 with zero-code observability for Kubernetes, targeting 1.0 GA in late 2026. [DEV Community](https://dev.to/x4nent/opentelemetry-ebpf-instrumentation-obi-the-complete-guide-kubecon-eu-2026-beta-launch-5e2o)
+- **Auto-diagnosing Kubernetes alerts with HolmesGPT** -- A two-person SRE team at STCLab shares how they built an AI investigation pipeline using HolmesGPT (CNCF Sandbox) with runbook-driven investigation. [CNCF Blog](https://www.cncf.io/blog/2026/04/21/auto-diagnosing-kubernetes-alerts-with-holmesgpt-and-cncf-tools/)
+- **Skyscanner shares OTel scaling story** -- Managing OpenTelemetry collectors across 24 production clusters with 1,000+ microservices. [OpenTelemetry Blog](https://opentelemetry.io/blog/2026/devex-skyscanner/)
+- **Kubernetes AI Gateway Working Group + Agent Sandbox** -- The community is building two complementary primitives: AI Gateway for inference traffic routing (KV-cache-aware scheduling) and Agent Sandbox for isolated, stateful agent runtimes. [Kubernetes Blog](https://kubernetes.io/blog/2026/04/08/running-agents-kubernetes-sandbox/)
+- **Grafana Cloud observability survey: 77% of orgs now lean on open source/open standards** -- Yet 38% still cite complexity as their top challenge. [Grafana Labs](https://grafana.com/observability-survey/)
+
+## My Take
+
+The same-day GPT-5.5 / DeepSeek V4 launches are the clearest signal yet that frontier AI is a commodity race. DeepSeek shipping 1.6T parameters under Apache 2.0 at a fraction of proprietary pricing means the moat isn't model intelligence -- it's the ecosystem you build around it. OpenAI is leaning hard into agentic coding and tool use; DeepSeek is betting that open weights and aggressive pricing will win the long game. Anthropic, meanwhile, is carving out a niche with safety-first features like the Cyber Verification Program.
+
+What interests me more is what's happening in the infrastructure layer underneath. Kubernetes 1.36's gang scheduling is a direct response to AI workloads that don't fit the one-pod-at-a-time scheduling model. The AI Gateway Working Group is tackling inference-specific routing (KV-cache pressure, LoRA adapter selection) that standard Gateway API can't handle. Grafana's Loki rearchitecture and AI Observability launch show that the observability stack is simultaneously being rebuilt for efficiency and extended to cover LLM workloads. And the Vercel breach is a sobering reminder that as we rush to integrate AI SaaS tools into our workflows, every OAuth grant is a potential lateral movement path.
+
+The convergence is real: AI is driving infrastructure changes, infrastructure is being built to serve AI, and observability is racing to cover both. The teams that will navigate this well are the ones treating AI not as a separate domain but as another class of distributed system that needs the same rigor around scheduling, security, and observability.
+
+---
+
+Thanks for reading this week's roundup. If something here caught your eye or I missed a story you think deserves attention, I'd love to hear about it -- reach out on [LinkedIn](https://www.linkedin.com/in/adityakonarde/). See you next week.

--- a/content/posts/week-in-review-ai-sre-observability-apr-17-24-2026.md
+++ b/content/posts/week-in-review-ai-sre-observability-apr-17-24-2026.md
@@ -12,7 +12,7 @@ canonicalURL: ""
 searchHidden: false
 ---
 
-If you blinked this week, you missed a model war. OpenAI dropped GPT-5.5 on Wednesday; DeepSeek shipped V4 -- open-source, 1.6T parameters, Apache 2.0 -- within hours. Meanwhile, Kubernetes 1.36 landed with gang scheduling for AI batch workloads, GrafanaCON in Barcelona delivered Grafana 13 and a ground-up Loki rearchitecture, and Vercel disclosed an OAuth supply-chain breach that should make every platform team audit their third-party integrations today. This was one of those weeks where multiple tectonic plates moved at once.
+If you blinked this week, you missed a model war. OpenAI dropped GPT-5.5 on Wednesday; DeepSeek shipped V4 -- open-source, 1.6T parameters, MIT -- within hours. Meanwhile, Kubernetes 1.36 landed with gang scheduling for AI batch workloads, GrafanaCON in Barcelona delivered Grafana 13 and a ground-up Loki rearchitecture, and Vercel disclosed an OAuth supply-chain breach that should make every platform team audit their third-party integrations today. This was one of those weeks where multiple tectonic plates moved at once.
 
 ## AI and Machine Learning
 
@@ -21,7 +21,7 @@ OpenAI shipped GPT-5.5 on April 23, calling it their smartest model yet. The hea
 [Source](https://openai.com/index/introducing-gpt-5-5/)
 
 **DeepSeek ships V4 -- open-source, 1.6T parameters, same-day counter-launch** --
-Hours after GPT-5.5, DeepSeek released V4 in preview: a 1.6T-parameter MoE model (49B activated) with a 1M-token context window, Apache 2.0 license, and weights on Hugging Face. The Flash variant (284B total, 13B activated) is separately trained, not a trimmed Pro. API pricing lands at $1.74/$3.48 per million tokens for Pro -- significantly cheaper than Opus 4.7, GPT-5.5, or competitors. V4 introduces Compressed Sparse Attention (CSA) and Heavily Compressed Attention (HCA) to cut KV cache requirements by roughly 10x. The model was pre-trained on 32T+ tokens using FP4+FP8 mixed precision. Huawei also announced its Ascend 950-based supernode will fully support V4.
+Hours after GPT-5.5, DeepSeek released V4 in preview: a 1.6T-parameter MoE model (49B activated) with a 1M-token context window, MIT license, and weights on Hugging Face. The Flash variant (284B total, 13B activated) is separately trained, not a trimmed Pro. API pricing lands at $1.74/$3.48 per million tokens for Pro -- significantly cheaper than Opus 4.7, GPT-5.5, or competitors. V4 introduces Compressed Sparse Attention (CSA) and Heavily Compressed Attention (HCA) to cut KV cache requirements by roughly 10x. The model was pre-trained on 32T+ tokens using FP4+FP8 mixed precision. Huawei also announced its Ascend 950-based supernode will fully support V4.
 [Source](https://api-docs.deepseek.com/news/news0424)
 
 **Anthropic launches Claude Opus 4.7 with stronger coding and high-res vision** --
@@ -35,7 +35,7 @@ Kubernetes 1.36 dropped on April 22 with 18 stable, 25 beta, and 25 alpha featur
 [Source](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/)
 
 **Vercel discloses OAuth supply-chain breach originating from third-party AI tool** --
-On April 19, Vercel disclosed a security incident that's become this week's must-read postmortem. The attack didn't start at Vercel -- it started at Context.ai, a third-party AI SaaS, where an employee was infected with Lumma Stealer. The attacker used stolen OAuth tokens to pivot through Google Workspace into a Vercel employee's corporate account, then accessed internal environments and read a subset of customer environment variables not marked "sensitive." The detection gap: roughly 22 months, from mid-2024 to April 2026. Mandiant and law enforcement are involved. The lesson is uncomfortable: your supply chain isn't just your code and npm packages anymore -- it's every SaaS app your employees authenticate with via OAuth.
+On April 19, Vercel disclosed a security incident that's become this week's must-read postmortem. The attack didn't start at Vercel -- it started at Context.ai, a third-party AI SaaS, where an employee was infected with Lumma Stealer. The attacker used stolen OAuth tokens to pivot through Google Workspace into a Vercel employee's corporate account, then accessed internal environments and read a subset of customer environment variables not marked "sensitive." The detection gap: roughly 2 months, from February 2026 to April 2026. Mandiant and law enforcement are involved. The lesson is uncomfortable: your supply chain isn't just your code and npm packages anymore -- it's every SaaS app your employees authenticate with via OAuth.
 [Source](https://vercel.com/blog/postmortem-supply-chain-attack)
 
 **Gateway API v1.5 ships biggest release yet -- six features graduate to stable** --
@@ -53,7 +53,7 @@ The most technically significant GrafanaCON announcement: Loki is getting a new 
 [Source](https://www.infoq.com/news/2026/04/grafana-loki-ai-agents/)
 
 **Grafana Labs targets the "AI blind spot" with LLM observability and agent-aware CLI** --
-Also at GrafanaCON: Grafana launched AI Observability in Grafana Cloud (public preview) for monitoring LLM-powered applications in production -- tracking token usage, latency, error rates, and evaluation metrics in real time. They also shipped GCX, a new agent-aware CLI designed to surface Grafana Cloud data inside agentic development environments. And o11y-bench, an open-source benchmark for evaluating AI agents running observability workflows, is now available. The quote from Jen Villa, Senior Director of Product: "AI systems are starting to look a lot like distributed systems did a decade ago: powerful, but difficult to reason about and even harder to operate."
+Also at GrafanaCON: Grafana launched AI Observability in Grafana Cloud (public preview) for monitoring LLM-powered applications in production -- tracking token usage, latency, error rates, and evaluation metrics in real time. They also shipped GCX, a new agent-aware CLI designed to surface Grafana Cloud data inside agentic development environments. And o11y-bench, an open-source benchmark for evaluating AI agents running observability workflows, is now available.
 [Source](https://grafana.com/press/2026/04/21/grafana-labs-targets-the-ai-blind-spot-with-new-observability-tools-announced-at-grafanacon-2026/)
 
 **OpenTelemetry formally deprecates OpenTracing compatibility requirements** --


### PR DESCRIPTION
## Summary

Weekly roundup post covering April 17–24, 2026 — a massive week across all three domains.

**AI/ML:** OpenAI ships GPT-5.5, DeepSeek counter-launches V4 (1.6T params, open-source Apache 2.0), Anthropic releases Claude Opus 4.7 with 3x vision resolution.

**SRE:** Kubernetes 1.36 "Haru" lands with gang scheduling for AI workloads, Vercel discloses OAuth supply-chain breach via Context.ai, Gateway API v1.5 ships 6 features to stable.

**Observability:** GrafanaCON 2026 delivers Grafana 13, Loki Kafka rearchitecture (eliminates 2.3x storage overhead), AI Observability in Cloud, and OpenTelemetry formally deprecates OpenTracing compatibility.

All 11 main stories and 6 quick links are sourced and linked to primary references.

## Review & Testing Checklist for Human

- [ ] **Verify source links**: Spot-check 3-4 of the linked sources to confirm they resolve and match the claims in the post (especially DeepSeek V4 and Vercel breach links)
- [ ] **Review factual accuracy**: Confirm key numbers (GPT-5.5 benchmarks, K8s 1.36 enhancement count, Loki 2.3x storage figure) against the linked sources
- [ ] **Preview the post locally** with `hugo server` to ensure markdown renders correctly, ToC works, and frontmatter is valid
- [ ] **Check tone and editorial voice**: Ensure the writing style matches your preferences and prior roundups

**Recommended test plan:** Run `hugo server -D` locally, navigate to the new post, and verify rendering, links, and section structure look correct on both desktop and mobile viewports.

### Notes

- Post follows the exact same frontmatter and section structure as the prior roundup (`week-in-review-ai-sre-observability-mar-20-27-2026.md`)
- The Vercel breach source link points to `vercel.com/blog/postmortem-supply-chain-attack` — if this URL has changed since the disclosure, it may need updating to the current bulletin URL
- DeepSeek V4 was released the same day as this post (April 24) so some details may still be evolving as the preview matures

Link to Devin session: https://app.devin.ai/sessions/f04602dd311e41acb1a141067ac081eb
Requested by: @aditya-konarde