### PR TITLE
Add weekly roundup: AI, SRE & Observability — April 24–30, 2026

### DIFF
--- a/content/posts/week-in-review-ai-sre-observability-apr-24-30-2026.md
+++ b/content/posts/week-in-review-ai-sre-observability-apr-24-30-2026.md
@@ -21,7 +21,7 @@ OpenAI released GPT-5.5, calling it the next step toward AI that actually does t
 [Source](https://help.openai.com/en/articles/11909943-gpt-53-and-gpt-55-in-chatgpt)
 
 **OpenAI ends Azure exclusivity, brings models to AWS Bedrock** --
-A day after restructuring its partnership with Microsoft, OpenAI announced its models will be available through Amazon Bedrock -- including a new "Managed Agents powered by OpenAI" service. This is seismic. OpenAI had been Azure-exclusive for years; now AWS customers can access OpenAI models and Codex with IAM, PrivateLink, guardrails, and CloudTrail logging baked in. Amazon invested $50 billion in OpenAI, while OpenAI committed $100 billion in AWS spend over eight years. The exclusivity era is definitively over.
+A day after restructuring its partnership with Microsoft, OpenAI announced its models will be available through Amazon Bedrock -- including a new "Managed Agents powered by OpenAI" service. This is seismic. OpenAI had been Azure-exclusive for years; now AWS customers can access OpenAI models and Codex with IAM, PrivateLink, guardrails, and CloudTrail logging baked in. Amazon invested $50 billion in OpenAI, while OpenAI committed $100 billion in additional AWS spend over eight years (on top of an existing $38B agreement). The exclusivity era is definitively over.
 [Source](https://aws.amazon.com/about-aws/whats-new/2026/04/bedrock-openai-models-codex-managed-agents/)
 
 **Google pledges up to $40 billion for Anthropic** --
@@ -30,6 +30,10 @@ Google is investing up to $40 billion in Anthropic -- $10 billion upfront at a $
 
 **DeepMind's David Silver raises $1.1B for reinforcement-learning AI startup** --
 David Silver, the researcher behind AlphaZero at DeepMind, has raised $1.1 billion at a $5.1 billion valuation for Ineffable Intelligence, a new lab aiming to build a "superlearner" that discovers knowledge without human data. The approach is pure reinforcement learning -- the same technique that beat world champions at chess and Go by learning entirely from self-play. Silver spent over a decade at DeepMind and brings deep expertise in the approach. If this works, it could represent a fundamentally different path from the LLM paradigm.
+**DeepSeek launches V4 -- 1.6 trillion parameter MoE, fully open-source under MIT** --
+DeepSeek released V4 on April 24, a Mixture-of-Experts model with 1.6 trillion total parameters (49 billion active per token). It uses a two-level routing MoE architecture and achieves competitive performance against GPT-5.5 and Claude Mythos on coding and reasoning benchmarks. DeepSeek claims V4 was trained for roughly $60 million -- a fraction of what US labs spend on comparable models. The model is available under an MIT license on Hugging Face, making it the most permissively licensed frontier-class model yet.
+[Source](https://www.cnbc.com/2026/04/24/deepseek-v4-china-open-source-ai-model.html)
+
 [Source](https://techcrunch.com/2026/04/27/deepminds-david-silver-just-raised-1-1b-to-build-an-ai-that-learns-without-human-data/)
 
 ## 🔧 Site Reliability Engineering

--- a/content/posts/week-in-review-ai-sre-observability-apr-24-30-2026.md
+++ b/content/posts/week-in-review-ai-sre-observability-apr-24-30-2026.md
@@ -1,0 +1,86 @@
+---
+title: "Week in Review: AI, SRE & Observability — April 24–30, 2026"
+date: 2026-05-01
+tags: ["ai", "sre", "observability", "weekly-roundup"]
+description: "OpenAI ships GPT-5.5 and breaks free from Azure exclusivity, Kubernetes 1.36 makes GPU scheduling a first-class citizen, Grafana rearchitects Loki with Kafka, and a 15-line Python script exposed Azure SRE Agent credentials."
+author: "Aditya Konarde"
+showToc: true
+TocOpen: true
+hidemeta: false
+comments: false
+canonicalURL: ""
+searchHidden: false
+---
+
+This was the week the AI industry's tectonic plates shifted. OpenAI launched GPT-5.5, then immediately broke free from its Azure-exclusive deal to land on AWS. Google responded by pledging up to $40 billion for Anthropic. Meanwhile, Kubernetes 1.36 "Haru" shipped with DRA maturing fast enough to make GPU scheduling on K8s genuinely viable, and GrafanaCON dropped a redesigned Loki architecture that could cut storage costs nearly in half. It was a big one.
+
+## 🤖 AI & Machine Learning
+
+**OpenAI launches GPT-5.5 -- its most capable model yet** --
+OpenAI released GPT-5.5, calling it the next step toward AI that actually does the work rather than just talking about it. Unlike previous models that needed step-by-step handholding, GPT-5.5 can take on messy, multi-part tasks autonomously -- planning, using tools, checking its own work, and navigating ambiguity. The coding benchmarks are particularly eye-catching: major leaps on Terminal-Bench 2.0 and agentic coding tasks. GPT-5.5 is rolling out to Plus, Pro, Business, and Enterprise users in ChatGPT, with API access coming soon.
+[Source](https://help.openai.com/en/articles/11909943-gpt-53-and-gpt-55-in-chatgpt)
+
+**OpenAI ends Azure exclusivity, brings models to AWS Bedrock** --
+A day after restructuring its partnership with Microsoft, OpenAI announced its models will be available through Amazon Bedrock -- including a new "Managed Agents powered by OpenAI" service. This is seismic. OpenAI had been Azure-exclusive for years; now AWS customers can access OpenAI models and Codex with IAM, PrivateLink, guardrails, and CloudTrail logging baked in. Amazon invested $50 billion in OpenAI, while OpenAI committed $100 billion in AWS spend over eight years. The exclusivity era is definitively over.
+[Source](https://aws.amazon.com/about-aws/whats-new/2026/04/bedrock-openai-models-codex-managed-agents/)
+
+**Google pledges up to $40 billion for Anthropic** --
+Google is investing up to $40 billion in Anthropic -- $10 billion upfront at a $380 billion valuation, with $30 billion more contingent on performance milestones. This comes on the heels of Anthropic releasing its Mythos model (its most powerful yet, with significant cybersecurity capabilities) and reports that Anthropic is weighing a fundraise that would value it at $900 billion, potentially surpassing OpenAI. The AI funding race has moved from billions to tens of billions, and the hyperscalers are all-in.
+[Source](https://techcrunch.com/2026/04/24/google-to-invest-up-to-40b-in-anthropic-in-cash-and-compute/)
+
+**DeepMind's David Silver raises $1.1B for reinforcement-learning AI startup** --
+David Silver, the researcher behind AlphaZero at DeepMind, has raised $1.1 billion at a $5.1 billion valuation for Ineffable Intelligence, a new lab aiming to build a "superlearner" that discovers knowledge without human data. The approach is pure reinforcement learning -- the same technique that beat world champions at chess and Go by learning entirely from self-play. Silver spent over a decade at DeepMind and brings deep expertise in the approach. If this works, it could represent a fundamentally different path from the LLM paradigm.
+[Source](https://techcrunch.com/2026/04/27/deepminds-david-silver-just-raised-1-1b-to-build-an-ai-that-learns-without-human-data/)
+
+## 🔧 Site Reliability Engineering
+
+**Kubernetes 1.36 "Haru" ships -- GPU scheduling and gang scheduling grow up** --
+Kubernetes v1.36 landed on April 22 with 70 enhancements, and the headline is clear: this is the release that makes AI workloads on K8s genuinely viable. Dynamic Resource Allocation (DRA) has multiple KEPs graduating to stable and beta, giving GPU/TPU workloads proper resource semantics beyond the old `nvidia.com/gpu: 2` integer model. Workload-Aware Scheduling (WAS) moves to beta, bringing gang scheduling into the mainline scheduler -- no more relying on Volcano or Kueue for "all pods must start together" semantics. Fine-grained kubelet API authorization graduates to GA, finally letting you grant monitoring agents metrics access without handing them `nodes/proxy` (a.k.a. "run anything on this node") permissions. The deprecated `gitRepo` volume plugin is permanently removed.
+[Source](https://kubernetes.io/blog/2026/04/24/kubernetes-v1-36-fine-grained-kubelet-authorization-ga/)
+
+**Azure East US suffers 14-hour multi-service outage** --
+On April 24, a platform issue in Azure's East US region caused widespread failures across VMs, AKS, Application Gateway, Databricks, and a dozen other services. The outage lasted approximately 14 hours, from 11:39 UTC to 00:15 UTC the next day. Customers experienced failures provisioning and scaling resources, plus intermittent connectivity issues on running workloads. Microsoft traced the root cause to a deployment that was subsequently rolled back. For teams running production in a single Azure region without cross-region failover, this was a painful reminder.
+[Source](https://isdown.app/status/azure/incidents/576072-active-multiservice-impact-for-azure-workloads-in-east-us)
+
+**Azure SRE Agent vulnerability exposed deployment credentials (CVE-2026-32173)** --
+Researchers from Enclave disclosed a critical authentication flaw (CVSS 8.6) in Microsoft's Azure SRE Agent -- a tool that autonomously restarts services, scales resources, and rolls back deployments. The vulnerability was remarkably simple: anyone with a free Azure account and roughly 15 lines of Python could connect to the Agent's SignalR hub and silently observe live deployment credentials in plaintext. The SRE Agent has access to source code, logs, metrics, and PagerDuty/ServiceNow integrations, making passive eavesdropping exceptionally damaging. Microsoft fixed it server-side without requiring customer action, but the incident raises uncomfortable questions about the security assumptions baked into AI-powered operations tools.
+[Source](https://www.pointguardai.com/ai-security-incidents/a-token-gap-let-outsiders-eavesdrop-on-azures-sre-agent-cve-2026-32173)
+
+## 🔭 Observability
+
+**GrafanaCON 2026: Grafana 13, Loki gets a Kafka-based architecture, and the gcx CLI arrives** --
+GrafanaCON in Barcelona was packed with announcements. The biggest: Loki is being rearchitected with Kafka at the ingestion layer. The old architecture replicated each log line to three ingesters for HA, but ingester drift meant deduplication by file name failed consistently -- internal metrics showed Grafana was storing 2.3x every log line on average. The new Kafka-backed approach eliminates this overhead entirely. Separately, Grafana Labs launched `gcx`, a CLI that brings Grafana Cloud data directly into the terminal and agentic coding environments. The pitch: your coding agent can now see production metrics, logs, and SLO status without context-switching to a browser.
+[Source](https://www.infoq.com/news/2026/04/grafana-loki-ai-agents/)
+
+**OpenTelemetry Collector v0.151.0 adds declarative schema support** --
+The latest OTel Collector release introduces declarative schema support for service telemetry resource configuration -- meaning you can now specify `schema_url` alongside explicit name/value attribute pairs instead of relying solely on inline attribute maps. The contrib release also ships breaking changes: the Splunk HEC exporter drops the deprecated `batcher` config field, the SignalFx exporter defaults shift from `*.signalfx.com` to `*.observability.splunkcloud.com`, and the Zipkin translator promotes new semantic convention feature gates to beta. If you're running OTel Collectors in production, review the breaking changes before upgrading.
+[Source](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.151.0)
+
+**Datadog launches GPU Monitoring for AI workload cost management** --
+Datadog released GPU Monitoring, aiming to solve one of the fastest-growing pain points in AI infrastructure: GPU cost visibility. The product ties GPU fleet telemetry directly to the workloads consuming those resources, giving platform and ML teams a shared view of health, cost, and performance. According to Datadog, GPU instances now account for 14% of compute costs at organizations running AI workloads, yet most teams can't attribute those costs to specific business units or identify idle resources. This is the first product to unify GPU observability across training and inference workloads in a single pane.
+[Source](https://finance.yahoo.com/markets/stocks/articles/datadog-gpu-monitoring-targets-ai-230438200.html)
+
+**OTel Operator v0.150.0 ships critical .NET auto-instrumentation security fix** --
+The OpenTelemetry Operator v0.150.0 updates the default .NET auto-instrumentation version from 1.2.0 to 1.15.0 to address CVE-2026-40894 -- a security vulnerability in older versions. This is a breaking change due to HTTP semantic convention differences between versions, and existing Instrumentation CRs using 1.2.0 will not be automatically upgraded. The release also adds a `--watch-namespace` CLI flag and allows explicit security context configuration for auto-instrumentation init containers, which is a welcome addition for teams running under restricted Pod Security Admission policies.
+[Source](https://newreleases.io/project/github/open-telemetry/opentelemetry-operator/release/v0.150.0)
+
+## 🔗 Quick Links
+
+- **Hugging Face Transformers v5.7.0** -- Adds Poolside's Laguna MoE model and DEIMv2 real-time object detection. [GitHub](https://github.com/huggingface/transformers/releases/tag/v5.7.0)
+- **Microsoft Agent Framework v1.2.2** -- New Azure Content Understanding package and improvements to agent handoff and group chat. [GitHub](https://github.com/microsoft/agent-framework/releases/tag/python-1.2.2)
+- **Microsoft, Meta, and Google announce billions more in AI capex** -- All three reported massive infrastructure spending increases in earnings. Only Google convinced investors it's paying off. [Fortune](https://fortune.com/2026/04/29/microsoft-meta-google-ai-capex-spending-billions/)
+- **Anthropic weighs fundraise at $900B valuation** -- Would surpass OpenAI if completed. [CNBC](https://www.cnbc.com/2026/04/29/anthropic-weighs-raising-funds-at-900b-valuation-topping-openai.html)
+- **Datadog ARFBench** -- A new time-series question-answering benchmark based on real incidents, designed to evaluate AI's ability to triage production issues. [Datadog Blog](https://www.datadoghq.com/blog/ai/introducing-arfbench/)
+- **Mastra AI Framework v1.29.0** -- Adds Azure Blob Storage workspace, `streamUntilIdle()` for background tasks, and Cloudflare Workers support for MCP. [GitHub](https://github.com/mastra-ai/mastra/releases/tag/%40mastra/core%401.29.0)
+
+## 💬 My Take
+
+The through-line this week is the collapse of moats. OpenAI's models on AWS. Google's billions flowing to a competitor's lab. Kubernetes making GPU scheduling a community-governed primitive. These aren't isolated events -- they're symptoms of an industry where the competitive advantage is shifting from "exclusive access" to "best integration."
+
+The Azure SRE Agent vulnerability is the story I keep coming back to, though. We're racing to give AI agents access to production systems -- restart services, roll back deployments, manage incidents -- and a 15-line Python script could silently watch it all happen. The security model for autonomous operations agents is still catching up to the ambition. As SRE teams adopt these tools (and they will), the blast radius of a credential leak isn't just "someone reads your data" -- it's "someone watches your AI make production changes in real-time." That's a fundamentally different threat model, and the industry hasn't fully internalized it yet.
+
+Meanwhile, the Loki rearchitecture is quietly one of the most impactful announcements of the week. Cutting effective storage from 2.3x to 1x per log line doesn't sound sexy, but for teams spending six figures a month on log storage, that's real money back in the budget. Combined with Datadog's GPU Monitoring launch, there's a clear pattern emerging: observability vendors are finally treating cost as a first-class signal alongside latency and error rates.
+
+---
+
+Thanks for reading this week's roundup. If something here caught your eye or I missed a story you think deserves attention, I'd love to hear about it -- reach out on [LinkedIn](https://www.linkedin.com/in/adityakonarde/). See you next week.


### PR DESCRIPTION
## Summary

Adds the weekly roundup blog post covering April 24–30, 2026. This was a major week across all three domains:

**AI/ML**: OpenAI shipped GPT-5.5 and broke free from Azure exclusivity to land on AWS Bedrock. Google pledged up to $40B for Anthropic. David Silver (AlphaZero) raised $1.1B for a reinforcement-learning-first AI lab.

**SRE**: Kubernetes 1.36 "Haru" shipped with maturing DRA for GPU workloads and gang scheduling moving to beta. Azure East US had a 14-hour multi-service outage. A critical Azure SRE Agent vulnerability (CVE-2026-32173) exposed deployment credentials via 15 lines of Python.

**Observability**: GrafanaCON 2026 dropped Grafana 13 and a Kafka-backed Loki rearchitecture that eliminates 2.3x storage overhead. OTel Collector v0.151.0 added declarative schema support. Datadog launched GPU Monitoring for AI cost management.

All stories are sourced from official release notes, engineering blogs, and reputable tech news outlets. Format and frontmatter match existing roundup posts.

## Review & Testing Checklist for Human

- [ ] Verify all source links resolve and point to the correct stories
- [ ] Review the "My Take" editorial for tone and accuracy
- [ ] Confirm the date range and publication date are correct (covering April 24–30, published May 1)

### Notes

Post follows the same structure, frontmatter, and style conventions as previous roundups (e.g., `week-in-review-ai-sre-observability-mar-20-27-2026.md`). Markdown lint passes cleanly.

Link to Devin session: https://app.devin.ai/sessions/7fae17b50d204360a1cfb51b3067df6b
Requested by: @aditya-konarde